### PR TITLE
Corrected mispelling of NetworkObject.

### DIFF
--- a/schema/rdf-owl/nml-mrs-ext-v2.owl
+++ b/schema/rdf-owl/nml-mrs-ext-v2.owl
@@ -520,7 +520,7 @@
     <!-- http://schemas.ogf.org/mrs/2013/12/topology#hasBatch -->
 
     <owl:ObjectProperty rdf:about="http://schemas.ogf.org/mrs/2013/12/topology#hasBatch">
-        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetwrokObject"/>
+        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetworkObject"/>
         <rdfs:range rdf:resource="http://schemas.ogf.org/mrs/2013/12/topology#Batch"/>
     </owl:ObjectProperty>
     
@@ -570,21 +570,21 @@
     <!-- http://schemas.ogf.org/mrs/2013/12/topology#capacity -->
 
     <owl:DatatypeProperty rdf:about="http://schemas.ogf.org/mrs/2013/12/topology#capacity">
-        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetwrokObject"/>
+        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetworkObject"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
     </owl:DatatypeProperty>
     
     <!-- http://schemas.ogf.org/mrs/2013/12/topology#capability -->
 
     <owl:DatatypeProperty rdf:about="http://schemas.ogf.org/mrs/2013/12/topology#capability">
-        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetwrokObject"/>
+        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetworkObject"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
     </owl:DatatypeProperty>
 
     <!-- http://schemas.ogf.org/mrs/2013/12/topology#measurement -->
 
     <owl:DatatypeProperty rdf:about="http://schemas.ogf.org/mrs/2013/12/topology#measurement">
-        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetwrokObject"/>
+        <rdfs:domain rdf:resource="http://schemas.ogf.org/nml/2013/03/base#NetworkObject"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
     </owl:DatatypeProperty>
 


### PR DESCRIPTION
There were four occurances of NetworkObject spelled as NetwrokObject.  This has been corrected and closes issue https://github.com/MAX-UMD/nml-mrml/issues/8.